### PR TITLE
fix: case insensitive tag finding

### DIFF
--- a/src/Tag.ts
+++ b/src/Tag.ts
@@ -8,7 +8,8 @@ const END_CLASS = `.${END_SELECTOR}`;
 export class Tag {
   private _text: string;
   constructor(tag: string) {
-    this._text = tag;
+    const clean = tag.replace("#", "").toLocaleLowerCase();
+    this._text = clean;
   }
 
   /**
@@ -94,7 +95,7 @@ export class Tag {
     if (element instanceof Tag) return element;
     const content: string =
       typeof element === "string" ? element : element.textContent;
-    return new Tag(content.replace("#", ""));
+    return new Tag(content);
   }
 
   /**

--- a/src/utils/find-tags.ts
+++ b/src/utils/find-tags.ts
@@ -8,7 +8,8 @@ export function getAllVaultTags(app: App): Set<string> {
     const tags = getAllTags(app.metadataCache.getCache(file.path)) || [];
     if (!tags.length) continue;
     for (let tag of tags) {
-      result.add(tag);
+      // Lower case tags as get fetch them
+      result.add(tag.toLocaleLowerCase());
     }
   }
   return result;


### PR DESCRIPTION
- Case insensitive tag finding
- Lowercase a `Tag` when we create it
- Lowercase all tags as we find them that way when we try and compare they all match